### PR TITLE
Refactor/custom headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ node_modules
 .next/
 issues/
 test/
+examples/

--- a/src/core/authentication/testAuthentication.ts
+++ b/src/core/authentication/testAuthentication.ts
@@ -36,16 +36,16 @@ export const testAuthentication = async (config: PinataConfig | undefined) => {
 		throw new ValidationError("Pinata configuration or JWT is missing");
 	}
 
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			Source: "sdk/testAuthentication",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/testAuthentication";
 
 	try {
 		const request = await fetch(

--- a/src/core/authentication/testAuthentication.ts
+++ b/src/core/authentication/testAuthentication.ts
@@ -37,6 +37,11 @@ export const testAuthentication = async (config: PinataConfig | undefined) => {
 	}
 
 	let headers: Record<string, string>;
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
 
 	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
 		headers = { ...config.customHeaders };
@@ -48,13 +53,10 @@ export const testAuthentication = async (config: PinataConfig | undefined) => {
 	}
 
 	try {
-		const request = await fetch(
-			"https://api.pinata.cloud/data/testAuthentication",
-			{
-				method: "GET",
-				headers: headers,
-			},
-		);
+		const request = await fetch(`${endpoint}/data/testAuthentication`, {
+			method: "GET",
+			headers: headers,
+		});
 		if (!request.ok) {
 			const errorData = await request.json();
 			if (request.status === 401) {

--- a/src/core/data/listFiles.ts
+++ b/src/core/data/listFiles.ts
@@ -124,16 +124,16 @@ export const listFiles = async (
 	const url = `https://api.pinata.cloud/data/pinList?status=pinned&${params.toString()}`;
 
 	try {
-		const headers: Record<string, string> = {
-			Authorization: `Bearer ${config?.pinataJwt}`,
-		};
+		let headers: Record<string, string>;
 
-		if (config.customHeaders) {
-			Object.assign(headers, config.customHeaders);
+		if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+			headers = { ...config.customHeaders };
+		} else {
+			headers = {
+				Authorization: `Bearer ${config.pinataJwt}`,
+				Source: "sdk/listFiles",
+			};
 		}
-
-		// biome-ignore lint/complexity/useLiteralKeys: non-issue
-		headers["Source"] = headers["Source"] || "sdk/listFiles";
 
 		const request = await fetch(url, {
 			method: "GET",

--- a/src/core/data/listFiles.ts
+++ b/src/core/data/listFiles.ts
@@ -121,7 +121,13 @@ export const listFiles = async (
 		}
 	}
 
-	const url = `https://api.pinata.cloud/data/pinList?status=pinned&${params.toString()}`;
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
+	const url = `${endpoint}/data/pinList?status=pinned&${params.toString()}`;
 
 	try {
 		let headers: Record<string, string>;

--- a/src/core/data/pinJobs.ts
+++ b/src/core/data/pinJobs.ts
@@ -65,16 +65,16 @@ export const pinJobs = async (
 
 	const url = `https://api.pinata.cloud/pinning/pinJobs?${params.toString()}`;
 
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			Source: "sdk/pinJobs",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/pinJobs";
 
 	try {
 		const request = await fetch(url, {

--- a/src/core/data/pinJobs.ts
+++ b/src/core/data/pinJobs.ts
@@ -63,7 +63,13 @@ export const pinJobs = async (
 		if (offset) params.append("offset", offset.toString());
 	}
 
-	const url = `https://api.pinata.cloud/pinning/pinJobs?${params.toString()}`;
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
+	const url = `${endpoint}/pinning/pinJobs?${params.toString()}`;
 
 	let headers: Record<string, string>;
 

--- a/src/core/data/pinnedFileUsage.ts
+++ b/src/core/data/pinnedFileUsage.ts
@@ -39,7 +39,11 @@ export const pinnedFileCount = async (
 		throw new ValidationError("Pinata configuration or JWT is missing");
 	}
 
-	const url = "https://api.pinata.cloud/data/userPinnedDataTotal";
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
 
 	let headers: Record<string, string>;
 
@@ -53,7 +57,7 @@ export const pinnedFileCount = async (
 	}
 
 	try {
-		const request = await fetch(url, {
+		const request = await fetch(`${endpoint}/data/userPinnedDataTotal`, {
 			method: "GET",
 			headers: headers,
 		});

--- a/src/core/data/pinnedFileUsage.ts
+++ b/src/core/data/pinnedFileUsage.ts
@@ -41,16 +41,16 @@ export const pinnedFileCount = async (
 
 	const url = "https://api.pinata.cloud/data/userPinnedDataTotal";
 
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			Source: "sdk/pinnedFileUsage",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/pinnedFileUsage";
 
 	try {
 		const request = await fetch(url, {

--- a/src/core/data/totalStorageUsage.ts
+++ b/src/core/data/totalStorageUsage.ts
@@ -40,7 +40,11 @@ export const totalStorageUsage = async (
 		throw new ValidationError("Pinata configuration or JWT is missing");
 	}
 
-	const url = "https://api.pinata.cloud/data/userPinnedDataTotal";
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
 
 	let headers: Record<string, string>;
 
@@ -54,7 +58,7 @@ export const totalStorageUsage = async (
 	}
 
 	try {
-		const request = await fetch(url, {
+		const request = await fetch(`${endpoint}/data/userPinnedDataTotal`, {
 			method: "GET",
 			headers: headers,
 		});

--- a/src/core/data/totalStorageUsage.ts
+++ b/src/core/data/totalStorageUsage.ts
@@ -42,16 +42,16 @@ export const totalStorageUsage = async (
 
 	const url = "https://api.pinata.cloud/data/userPinnedDataTotal";
 
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			Source: "sdk/totalStorageUsage",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/totalStorageUsage";
 
 	try {
 		const request = await fetch(url, {

--- a/src/core/data/updateMetadata.ts
+++ b/src/core/data/updateMetadata.ts
@@ -67,15 +67,18 @@ export const updateMetadata = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch(
-			"https://api.pinata.cloud/pinning/hashMetadata",
-			{
-				method: "PUT",
-				headers: headers,
-				body: JSON.stringify(data),
-			},
-		);
+		const request = await fetch(`${endpoint}/pinning/hashMetadata`, {
+			method: "PUT",
+			headers: headers,
+			body: JSON.stringify(data),
+		});
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/data/updateMetadata.ts
+++ b/src/core/data/updateMetadata.ts
@@ -55,17 +55,17 @@ export const updateMetadata = async (
 		keyvalues: options.keyValues,
 	};
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/updateMetadata",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/updateMetadata";
 
 	try {
 		const request = await fetch(

--- a/src/core/groups/addToGroup.ts
+++ b/src/core/groups/addToGroup.ts
@@ -62,15 +62,18 @@ export const addToGroup = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch(
-			`https://api.pinata.cloud/groups/${options.groupId}/cids`,
-			{
-				method: "PUT",
-				headers: headers,
-				body: data,
-			},
-		);
+		const request = await fetch(`${endpoint}/groups/${options.groupId}/cids`, {
+			method: "PUT",
+			headers: headers,
+			body: data,
+		});
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/groups/addToGroup.ts
+++ b/src/core/groups/addToGroup.ts
@@ -50,17 +50,17 @@ export const addToGroup = async (
 		cids: options.cids,
 	});
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/addToGroup",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/addToGroup";
 
 	try {
 		const request = await fetch(

--- a/src/core/groups/createGroup.ts
+++ b/src/core/groups/createGroup.ts
@@ -47,17 +47,17 @@ export const createGroup = async (
 
 	const data = JSON.stringify(options);
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/createGroup",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/createGroup";
 
 	try {
 		const request = await fetch("https://api.pinata.cloud/groups", {

--- a/src/core/groups/createGroup.ts
+++ b/src/core/groups/createGroup.ts
@@ -59,8 +59,14 @@ export const createGroup = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch("https://api.pinata.cloud/groups", {
+		const request = await fetch(`${endpoint}/groups`, {
 			method: "POST",
 			headers: headers,
 			body: data,

--- a/src/core/groups/deleteGroup.ts
+++ b/src/core/groups/deleteGroup.ts
@@ -58,14 +58,17 @@ export const deleteGroup = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch(
-			`https://api.pinata.cloud/groups/${options.groupId}`,
-			{
-				method: "DELETE",
-				headers: headers,
-			},
-		);
+		const request = await fetch(`${endpoint}/groups/${options.groupId}`, {
+			method: "DELETE",
+			headers: headers,
+		});
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/groups/deleteGroup.ts
+++ b/src/core/groups/deleteGroup.ts
@@ -46,17 +46,17 @@ export const deleteGroup = async (
 		throw new ValidationError("Pinata configuration or JWT is missing");
 	}
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/deleteGroup",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/deleteGroup";
 
 	try {
 		const request = await fetch(

--- a/src/core/groups/getGroup.ts
+++ b/src/core/groups/getGroup.ts
@@ -49,17 +49,17 @@ export const getGroup = async (
 		throw new ValidationError("Pinata configuration or JWT is missing");
 	}
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/getGroup",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/getGroup";
 
 	try {
 		const request = await fetch(

--- a/src/core/groups/getGroup.ts
+++ b/src/core/groups/getGroup.ts
@@ -61,14 +61,17 @@ export const getGroup = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch(
-			`https://api.pinata.cloud/groups/${options.groupId}`,
-			{
-				method: "GET",
-				headers: headers,
-			},
-		);
+		const request = await fetch(`${endpoint}/groups/${options.groupId}`, {
+			method: "GET",
+			headers: headers,
+		});
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/groups/listGroups.ts
+++ b/src/core/groups/listGroups.ts
@@ -51,17 +51,17 @@ export const listGroups = async (
 		throw new ValidationError("Pinata configuration or JWT is missing");
 	}
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/listGroups",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/listGroups";
 
 	const params = new URLSearchParams();
 

--- a/src/core/groups/listGroups.ts
+++ b/src/core/groups/listGroups.ts
@@ -74,10 +74,14 @@ export const listGroups = async (
 		if (limit !== undefined) params.append("limit", limit.toString());
 	}
 
-	const url = `https://api.pinata.cloud/groups?${params.toString()}`;
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
 
 	try {
-		const request = await fetch(url, {
+		const request = await fetch(`${endpoint}/groups?${params.toString()}`, {
 			method: "GET",
 			headers: headers,
 		});

--- a/src/core/groups/removeFromGroup.ts
+++ b/src/core/groups/removeFromGroup.ts
@@ -47,17 +47,17 @@ export const removeFromGroup = async (
 		throw new ValidationError("Pinata configuration or JWT is missing");
 	}
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/removeFromGroup",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/removeFromGroup";
 
 	const data = JSON.stringify({
 		cids: options.cids,

--- a/src/core/groups/removeFromGroup.ts
+++ b/src/core/groups/removeFromGroup.ts
@@ -63,15 +63,18 @@ export const removeFromGroup = async (
 		cids: options.cids,
 	});
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch(
-			`https://api.pinata.cloud/groups/${options.groupId}/cids`,
-			{
-				method: "DELETE",
-				headers: headers,
-				body: data,
-			},
-		);
+		const request = await fetch(`${endpoint}/groups/${options.groupId}/cids`, {
+			method: "DELETE",
+			headers: headers,
+			body: data,
+		});
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/groups/updateGroup.ts
+++ b/src/core/groups/updateGroup.ts
@@ -67,15 +67,18 @@ export const updateGroup = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch(
-			`https://api.pinata.cloud/groups/${options.groupId}`,
-			{
-				method: "PUT",
-				headers: headers,
-				body: data,
-			},
-		);
+		const request = await fetch(`${endpoint}/groups/${options.groupId}`, {
+			method: "PUT",
+			headers: headers,
+			body: data,
+		});
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/groups/updateGroup.ts
+++ b/src/core/groups/updateGroup.ts
@@ -55,17 +55,17 @@ export const updateGroup = async (
 		name: options.name,
 	});
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/updateGroup",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/updateGroup";
 
 	try {
 		const request = await fetch(

--- a/src/core/keys/createKey.ts
+++ b/src/core/keys/createKey.ts
@@ -52,17 +52,17 @@ export const createKey = async (
 		throw new ValidationError("Pinata configuration or JWT is missing");
 	}
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/createKey",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/createKey";
 
 	const data = JSON.stringify(options);
 

--- a/src/core/keys/createKey.ts
+++ b/src/core/keys/createKey.ts
@@ -66,8 +66,14 @@ export const createKey = async (
 
 	const data = JSON.stringify(options);
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch("https://api.pinata.cloud/v3/pinata/keys", {
+		const request = await fetch(`${endpoint}/v3/pinata/keys`, {
 			method: "POST",
 			headers: headers,
 			body: data,

--- a/src/core/keys/listKeys.ts
+++ b/src/core/keys/listKeys.ts
@@ -55,17 +55,17 @@ export const listKeys = async (
 		throw new ValidationError("Pinata configuration or JWT is missing");
 	}
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/listKeys",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/listKeys";
 
 	const params = new URLSearchParams();
 

--- a/src/core/keys/listKeys.ts
+++ b/src/core/keys/listKeys.ts
@@ -81,13 +81,20 @@ export const listKeys = async (
 		if (name) params.append("name", name);
 	}
 
-	const url = `https://api.pinata.cloud/v3/pinata/keys?${params.toString()}`;
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
 
 	try {
-		const request = await fetch(url, {
-			method: "GET",
-			headers: headers,
-		});
+		const request = await fetch(
+			`${endpoint}/v3/pinata/keys?${params.toString()}`,
+			{
+				method: "GET",
+				headers: headers,
+			},
+		);
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/keys/revokeKeys.ts
+++ b/src/core/keys/revokeKeys.ts
@@ -65,15 +65,18 @@ export const revokeKeys = async (
 
 	const responses: RevokeKeyResponse[] = [];
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	for (const key of keys) {
 		try {
-			const request = await fetch(
-				`https://api.pinata.cloud/v3/pinata/keys/${key}`,
-				{
-					method: "PUT",
-					headers: headers,
-				},
-			);
+			const request = await fetch(`${endpoint}/v3/pinata/keys/${key}`, {
+				method: "PUT",
+				headers: headers,
+			});
 
 			await wait(300);
 

--- a/src/core/keys/revokeKeys.ts
+++ b/src/core/keys/revokeKeys.ts
@@ -51,17 +51,17 @@ export const revokeKeys = async (
 		throw new ValidationError("Pinata configuration or JWT is missing");
 	}
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/revokeKeys",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/revokeKeys";
 
 	const responses: RevokeKeyResponse[] = [];
 

--- a/src/core/pinataSDK.ts
+++ b/src/core/pinataSDK.ts
@@ -87,6 +87,21 @@ export class PinataSDK {
 		this.signatures = new Signatures(this.config);
 	}
 
+	setNewHeaders(headers: Record<string, string>): void {
+		if (!this.config) {
+			this.config = { pinataJwt: "", customHeaders: {} };
+		}
+		this.config.customHeaders = { ...this.config.customHeaders, ...headers };
+
+		// Update headers for all sub-modules
+		this.upload.updateConfig(this.config);
+		this.gateways.updateConfig(this.config);
+		this.usage.updateConfig(this.config);
+		this.keys.updateConfig(this.config);
+		this.groups.updateConfig(this.config);
+		this.signatures.updateConfig(this.config);
+	}
+
 	testAuthentication(): Promise<AuthTestResponse> {
 		return testAuthentication(this.config);
 	}
@@ -199,6 +214,10 @@ class Upload {
 
 	constructor(config?: PinataConfig) {
 		this.config = formatConfig(config);
+	}
+
+	updateConfig(newConfig: PinataConfig): void {
+		this.config = newConfig;
 	}
 
 	file(file: FileObject, options?: UploadOptions): UploadBuilder<PinResponse> {
@@ -365,6 +384,10 @@ class Gateways {
 		this.config = formatConfig(config);
 	}
 
+	updateConfig(newConfig: PinataConfig): void {
+		this.config = newConfig;
+	}
+
 	get(cid: string): Promise<GetCIDResponse> {
 		return getCid(this.config, cid);
 	}
@@ -480,6 +503,10 @@ class Usage {
 		this.config = formatConfig(config);
 	}
 
+	updateConfig(newConfig: PinataConfig): void {
+		this.config = newConfig;
+	}
+
 	pinnedFileCount(): Promise<number> {
 		return pinnedFileCount(this.config);
 	}
@@ -494,6 +521,10 @@ class Keys {
 
 	constructor(config?: PinataConfig) {
 		this.config = formatConfig(config);
+	}
+
+	updateConfig(newConfig: PinataConfig): void {
+		this.config = newConfig;
 	}
 
 	create(options: KeyOptions): Promise<KeyResponse> {
@@ -602,6 +633,10 @@ class Groups {
 
 	constructor(config?: PinataConfig) {
 		this.config = formatConfig(config);
+	}
+
+	updateConfig(newConfig: PinataConfig): void {
+		this.config = newConfig;
 	}
 
 	create(options: GroupOptions): Promise<GroupResponseItem> {
@@ -722,6 +757,10 @@ class Signatures {
 
 	constructor(config?: PinataConfig) {
 		this.config = formatConfig(config);
+	}
+
+	updateConfig(newConfig: PinataConfig): void {
+		this.config = newConfig;
 	}
 
 	add(options: SignatureOptions): Promise<SignatureResponse> {

--- a/src/core/pinning/base64.ts
+++ b/src/core/pinning/base64.ts
@@ -80,16 +80,16 @@ export const uploadBase64 = async (
 		}),
 	);
 
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${jwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${jwt}`,
+			Source: "sdk/base64",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/base64";
 
 	try {
 		const request = await fetch(

--- a/src/core/pinning/base64.ts
+++ b/src/core/pinning/base64.ts
@@ -91,15 +91,18 @@ export const uploadBase64 = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch(
-			"https://api.pinata.cloud/pinning/pinFileToIPFS",
-			{
-				method: "POST",
-				headers: headers,
-				body: data,
-			},
-		);
+		const request = await fetch(`${endpoint}/pinning/pinFileToIPFS`, {
+			method: "POST",
+			headers: headers,
+			body: data,
+		});
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/pinning/cid.ts
+++ b/src/core/pinning/cid.ts
@@ -81,8 +81,14 @@ export const uploadCid = async (
 		},
 	});
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch("https://api.pinata.cloud/pinning/pinByHash", {
+		const request = await fetch(`${endpoint}/pinning/pinByHash`, {
 			method: "POST",
 			headers: headers,
 			body: data,

--- a/src/core/pinning/cid.ts
+++ b/src/core/pinning/cid.ts
@@ -57,17 +57,17 @@ export const uploadCid = async (
 
 	const jwt: string = options?.keys || config?.pinataJwt;
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${jwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${jwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/cid",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/cid";
 
 	const data = JSON.stringify({
 		hashToPin: cid,

--- a/src/core/pinning/file.ts
+++ b/src/core/pinning/file.ts
@@ -71,16 +71,16 @@ export const uploadFile = async (
 		}),
 	);
 
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${jwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${jwt}`,
+			Source: "sdk/file",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/file";
 
 	try {
 		const request = await fetch(

--- a/src/core/pinning/file.ts
+++ b/src/core/pinning/file.ts
@@ -82,15 +82,18 @@ export const uploadFile = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch(
-			"https://api.pinata.cloud/pinning/pinFileToIPFS",
-			{
-				method: "POST",
-				headers: headers,
-				body: data,
-			},
-		);
+		const request = await fetch(`${endpoint}/pinning/pinFileToIPFS`, {
+			method: "POST",
+			headers: headers,
+			body: data,
+		});
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/pinning/fileArray.ts
+++ b/src/core/pinning/fileArray.ts
@@ -78,16 +78,16 @@ export const uploadFileArray = async (
 		}),
 	);
 
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${jwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${jwt}`,
+			Source: "sdk/fileArray",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/fileArray";
 
 	try {
 		const request = await fetch(

--- a/src/core/pinning/fileArray.ts
+++ b/src/core/pinning/fileArray.ts
@@ -89,15 +89,18 @@ export const uploadFileArray = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch(
-			"https://api.pinata.cloud/pinning/pinFileToIPFS",
-			{
-				method: "POST",
-				headers: headers,
-				body: data,
-			},
-		);
+		const request = await fetch(`${endpoint}/pinning/pinFileToIPFS`, {
+			method: "POST",
+			headers: headers,
+			body: data,
+		});
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/pinning/json.ts
+++ b/src/core/pinning/json.ts
@@ -75,17 +75,17 @@ export const uploadJson = async <T extends JsonBody>(
 		},
 	});
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${jwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${jwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/json",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/json";
 
 	try {
 		const request = await fetch(

--- a/src/core/pinning/json.ts
+++ b/src/core/pinning/json.ts
@@ -87,15 +87,18 @@ export const uploadJson = async <T extends JsonBody>(
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch(
-			"https://api.pinata.cloud/pinning/pinJSONToIPFS",
-			{
-				method: "POST",
-				headers: headers,
-				body: data,
-			},
-		);
+		const request = await fetch(`${endpoint}/pinning/pinJSONToIPFS`, {
+			method: "POST",
+			headers: headers,
+			body: data,
+		});
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/pinning/unpin.ts
+++ b/src/core/pinning/unpin.ts
@@ -52,17 +52,16 @@ export const unpinFile = async (
 
 	const responses: UnpinResponse[] = [];
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			Source: "sdk/unpin",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/unpin";
 
 	for (const hash of files) {
 		try {

--- a/src/core/pinning/unpin.ts
+++ b/src/core/pinning/unpin.ts
@@ -63,15 +63,18 @@ export const unpinFile = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	for (const hash of files) {
 		try {
-			const response = await fetch(
-				`https://api.pinata.cloud/pinning/unpin/${hash}`,
-				{
-					method: "DELETE",
-					headers: headers,
-				},
-			);
+			const response = await fetch(`${endpoint}/pinning/unpin/${hash}`, {
+				method: "DELETE",
+				headers: headers,
+			});
 
 			await wait(300);
 

--- a/src/core/pinning/url.ts
+++ b/src/core/pinning/url.ts
@@ -91,16 +91,16 @@ export const uploadUrl = async (
 		}),
 	);
 
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${jwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${jwt}`,
+			Source: "sdk/url",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/url";
 
 	try {
 		const request = await fetch(

--- a/src/core/pinning/url.ts
+++ b/src/core/pinning/url.ts
@@ -102,15 +102,18 @@ export const uploadUrl = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch(
-			"https://api.pinata.cloud/pinning/pinFileToIPFS",
-			{
-				method: "POST",
-				headers: headers,
-				body: data,
-			},
-		);
+		const request = await fetch(`${endpoint}/pinning/pinFileToIPFS`, {
+			method: "POST",
+			headers: headers,
+			body: data,
+		});
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/signatures/addSignature.ts
+++ b/src/core/signatures/addSignature.ts
@@ -56,17 +56,17 @@ export const addSignature = async (
 		signature: options.signature,
 	});
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/addSignature",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/addSignature";
 
 	try {
 		const request = await fetch(

--- a/src/core/signatures/addSignature.ts
+++ b/src/core/signatures/addSignature.ts
@@ -68,9 +68,15 @@ export const addSignature = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
 		const request = await fetch(
-			`https://api.pinata.cloud/v3/ipfs/signature/${options.cid}`,
+			`${endpoint}/v3/ipfs/signature/${options.cid}`,
 			{
 				method: "POST",
 				headers: headers,

--- a/src/core/signatures/getSignature.ts
+++ b/src/core/signatures/getSignature.ts
@@ -56,14 +56,17 @@ export const getSignature = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch(
-			`https://api.pinata.cloud/v3/ipfs/signature/${cid}`,
-			{
-				method: "GET",
-				headers: headers,
-			},
-		);
+		const request = await fetch(`${endpoint}/v3/ipfs/signature/${cid}`, {
+			method: "GET",
+			headers: headers,
+		});
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/signatures/getSignature.ts
+++ b/src/core/signatures/getSignature.ts
@@ -44,17 +44,17 @@ export const getSignature = async (
 		throw new ValidationError("Pinata configuration or JWT is missing");
 	}
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/getSignature",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/getSignature";
 
 	try {
 		const request = await fetch(

--- a/src/core/signatures/removeSignature.ts
+++ b/src/core/signatures/removeSignature.ts
@@ -56,14 +56,17 @@ export const removeSignature = async (
 		};
 	}
 
+	let endpoint: string = "https://api.pinata.cloud";
+
+	if (config.endpointUrl) {
+		endpoint = config.endpointUrl;
+	}
+
 	try {
-		const request = await fetch(
-			`https://api.pinata.cloud/v3/ipfs/signature/${cid}`,
-			{
-				method: "DELETE",
-				headers: headers,
-			},
-		);
+		const request = await fetch(`${endpoint}/v3/ipfs/signature/${cid}`, {
+			method: "DELETE",
+			headers: headers,
+		});
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/src/core/signatures/removeSignature.ts
+++ b/src/core/signatures/removeSignature.ts
@@ -44,17 +44,17 @@ export const removeSignature = async (
 		throw new ValidationError("Pinata configuration or JWT is missing");
 	}
 
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: `Bearer ${config?.pinataJwt}`,
-	};
+	let headers: Record<string, string>;
 
-	if (config.customHeaders) {
-		Object.assign(headers, config.customHeaders);
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = { ...config.customHeaders };
+	} else {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			Source: "sdk/removeSignature",
+		};
 	}
-
-	// biome-ignore lint/complexity/useLiteralKeys: non-issue
-	headers["Source"] = headers["Source"] || "sdk/removeSignature";
 
 	try {
 		const request = await fetch(

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,6 +3,7 @@ export type PinataConfig = {
 	pinataGateway?: string;
 	pinataGatewayKey?: string;
 	customHeaders?: Record<string, string>;
+	endpointUrl?: string;
 };
 
 export type AuthTestResponse = {

--- a/tests/data/setHeaders.test.ts
+++ b/tests/data/setHeaders.test.ts
@@ -1,0 +1,68 @@
+import { PinataSDK } from "../../src/core/pinataSDK";
+import * as testAuthenticationModule from "../../src/core/authentication/testAuthentication";
+
+jest.mock("../../src/core/authentication/testAuthentication");
+
+describe("PinataSDK", () => {
+	let pinata: PinataSDK;
+	const mockTestAuthentication =
+		testAuthenticationModule.testAuthentication as jest.MockedFunction<
+			typeof testAuthenticationModule.testAuthentication
+		>;
+
+	beforeEach(() => {
+		pinata = new PinataSDK({
+			pinataJwt: "test_jwt",
+			pinataGateway: "test.gateway.com",
+		});
+		mockTestAuthentication.mockClear();
+	});
+
+	describe("setNewHeaders", () => {
+		it("should update custom headers", () => {
+			const newHeaders = { "X-Custom-Header": "CustomValue" };
+			pinata.setNewHeaders(newHeaders);
+
+			// @ts-ignore: Accessing private property for testing
+			expect(pinata.config.customHeaders).toEqual(newHeaders);
+		});
+
+		it("should merge new headers with existing ones", () => {
+			const initialHeaders = { "Initial-Header": "InitialValue" };
+			pinata.setNewHeaders(initialHeaders);
+
+			const newHeaders = { "X-Custom-Header": "CustomValue" };
+			pinata.setNewHeaders(newHeaders);
+
+			// @ts-ignore: Accessing private property for testing
+			expect(pinata.config.customHeaders).toEqual({
+				"Initial-Header": "InitialValue",
+				"X-Custom-Header": "CustomValue",
+			});
+		});
+
+		it("should override existing headers with new ones", () => {
+			const initialHeaders = { "X-Custom-Header": "InitialValue" };
+			pinata.setNewHeaders(initialHeaders);
+
+			const newHeaders = { "X-Custom-Header": "NewValue" };
+			pinata.setNewHeaders(newHeaders);
+
+			// @ts-ignore: Accessing private property for testing
+			expect(pinata.config.customHeaders).toEqual(newHeaders);
+		});
+
+		it("should use updated headers in API calls", async () => {
+			const newHeaders = { "X-Custom-Header": "CustomValue" };
+			pinata.setNewHeaders(newHeaders);
+
+			await pinata.testAuthentication();
+
+			expect(mockTestAuthentication).toHaveBeenCalledWith(
+				expect.objectContaining({
+					customHeaders: newHeaders,
+				}),
+			);
+		});
+	});
+});


### PR DESCRIPTION
- Added method `setNewHeaders` to update all headers on a config level and make them persist
- Added the ability to pass in a custom endpoint on the config level