### PR TITLE
fix: Removed Source header to fix CORS error

### DIFF
--- a/src/core/gateway/getCid.ts
+++ b/src/core/gateway/getCid.ts
@@ -55,12 +55,7 @@ export const getCid = async (
 	}
 
 	try {
-		const request = await fetch(newUrl, {
-			method: "GET",
-			headers: {
-				Source: "sdk/getCid",
-			},
-		});
+		const request = await fetch(newUrl);
 
 		if (!request.ok) {
 			const errorData = await request.json();

--- a/tests/gateway/getCid.test.ts
+++ b/tests/gateway/getCid.test.ts
@@ -130,7 +130,6 @@ describe("getCid function", () => {
 
 		expect(global.fetch).toHaveBeenCalledWith(
 			"https://test.mypinata.cloud/ipfs/QmTest...?pinataGatewayToken=test_gateway_key",
-			expect.any(Object),
 		);
 	});
 });


### PR DESCRIPTION
The `gateways.get` method had an unnecessary `Source` header that was causing CORS issues in client side fetching. Removed the header and adjusted unit test. 