### PR TITLE
Feat/upgrade gateway tools

### DIFF
--- a/src/core/gateway/convertIPFSUrl.ts
+++ b/src/core/gateway/convertIPFSUrl.ts
@@ -31,9 +31,12 @@ import type { PinataConfig } from "../types";
 export const convertIPFSUrl = async (
 	config: PinataConfig | undefined,
 	url: string,
+	gatewayPrefix?: string,
 ): Promise<string> => {
 	let newUrl: string;
-	newUrl = await convertToDesiredGateway(url, config?.pinataGateway);
+	let prefix: string =
+		gatewayPrefix || config?.pinataGateway || "https://gateway.pinata.cloud";
+	newUrl = await convertToDesiredGateway(url, prefix);
 	if (config?.pinataGatewayKey) {
 		`${newUrl}?pinataGatewayToken=${config?.pinataGatewayKey}`;
 	}

--- a/src/core/pinataSDK.ts
+++ b/src/core/pinataSDK.ts
@@ -35,6 +35,7 @@ import type {
 	SwapCidOptions,
 	SwapCidResponse,
 	SwapHistoryOptions,
+	ContainsCIDResponse,
 } from "./types";
 import { testAuthentication } from "./authentication/testAuthentication";
 import { uploadFile } from "./pinning/file";
@@ -69,6 +70,7 @@ import { analyticsDateInterval } from "./gateway/analyticsDateInterval";
 import { swapCid } from "./gateway/swapCid";
 import { swapHistory } from "./gateway/swapHistory";
 import { deleteSwap } from "./gateway/deleteSwap";
+import { containsCID } from "../utils/gateway-tools";
 
 const formatConfig = (config: PinataConfig | undefined) => {
 	let gateway = config?.pinataGateway;
@@ -405,10 +407,12 @@ class Gateways {
 		return getCid(this.config, cid);
 	}
 
-	convert(url: string): Promise<string> {
-		return convertIPFSUrl(this.config, url);
 	convert(url: string, gatewayPrefix?: string): Promise<string> {
 		return convertIPFSUrl(this.config, url, gatewayPrefix);
+	}
+
+	containsCID(cid: string): Promise<ContainsCIDResponse> {
+		return containsCID(cid);
 	}
 
 	topUsageAnalytics(options: {

--- a/src/core/pinataSDK.ts
+++ b/src/core/pinataSDK.ts
@@ -407,6 +407,8 @@ class Gateways {
 
 	convert(url: string): Promise<string> {
 		return convertIPFSUrl(this.config, url);
+	convert(url: string, gatewayPrefix?: string): Promise<string> {
+		return convertIPFSUrl(this.config, url, gatewayPrefix);
 	}
 
 	topUsageAnalytics(options: {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -372,3 +372,8 @@ export type SwapCidResponse = {
 	mappedCid: string;
 	createdAt: string;
 };
+
+export type ContainsCIDResponse = {
+	containsCid: boolean;
+	cid: string | null;
+};

--- a/src/utils/gateway-tools.ts
+++ b/src/utils/gateway-tools.ts
@@ -1,4 +1,5 @@
 import type * as IsIPFS from "is-ipfs";
+import { ContainsCIDResponse } from "../core/types";
 
 let isIPFSModule: typeof IsIPFS;
 
@@ -9,7 +10,7 @@ async function getIsIPFS() {
 	return isIPFSModule;
 }
 
-async function containsCID(input: string) {
+export async function containsCID(input: string): Promise<ContainsCIDResponse> {
 	if (typeof input !== "string") {
 		throw new Error("Input is not a string");
 	}


### PR DESCRIPTION
Added two new features to IPFS Gateway tools
- Ability to pass in an optional prefix to `gateways.convert` allowing another gateway prefix other than the default gateway in the SDK config
- Added `containsCID` method to `gateways` class which can be used to detect if a string contains a CID. If it does it will return a boolean as well as the CID outside of its original context