### PR TITLE
feat: Add optmizeImage method to gateways.get

### DIFF
--- a/src/core/gateway/getCid.ts
+++ b/src/core/gateway/getCid.ts
@@ -28,8 +28,11 @@
  */
 
 import { convertToDesiredGateway } from "../../utils/gateway-tools";
-import type { GetCIDResponse, PinataConfig } from "../types";
-
+import type {
+	GetCIDResponse,
+	PinataConfig,
+	OptimizeImageOptions,
+} from "../types";
 import {
 	PinataError,
 	NetworkError,
@@ -40,6 +43,7 @@ import {
 export const getCid = async (
 	config: PinataConfig | undefined,
 	cid: string,
+	options?: OptimizeImageOptions,
 ): Promise<GetCIDResponse> => {
 	if (!config) {
 		throw new ValidationError("Pinata configuration is missing");
@@ -50,8 +54,32 @@ export const getCid = async (
 
 	newUrl = await convertToDesiredGateway(cid, config?.pinataGateway);
 
+	const params = new URLSearchParams();
+
 	if (config?.pinataGatewayKey) {
-		newUrl = `${newUrl}?pinataGatewayToken=${config?.pinataGatewayKey}`;
+		params.append("pinataGatewayToken", config.pinataGatewayKey);
+	}
+
+	if (options) {
+		if (options.width) params.append("img-width", options.width.toString());
+		if (options.height) params.append("img-height", options.height.toString());
+		if (options.dpr) params.append("img-dpr", options.dpr.toString());
+		if (options.fit) params.append("img-fit", options.fit);
+		if (options.gravity) params.append("img-gravity", options.gravity);
+		if (options.quality)
+			params.append("img-quality", options.quality.toString());
+		if (options.format) params.append("img-format", options.format);
+		if (options.animation !== undefined)
+			params.append("img-anim", options.animation.toString());
+		if (options.sharpen)
+			params.append("img-sharpen", options.sharpen.toString());
+		if (options.onError === true) params.append("img-onerror", "redirect");
+		if (options.metadata) params.append("img-metadata", options.metadata);
+	}
+
+	const queryString = params.toString();
+	if (queryString) {
+		newUrl += `?${queryString}`;
 	}
 
 	try {

--- a/src/core/pinataSDK.ts
+++ b/src/core/pinataSDK.ts
@@ -36,6 +36,7 @@ import type {
 	SwapCidResponse,
 	SwapHistoryOptions,
 	ContainsCIDResponse,
+	OptimizeImageOptions,
 } from "./types";
 import { testAuthentication } from "./authentication/testAuthentication";
 import { uploadFile } from "./pinning/file";
@@ -403,8 +404,8 @@ class Gateways {
 		this.config = newConfig;
 	}
 
-	get(cid: string): Promise<GetCIDResponse> {
-		return getCid(this.config, cid);
+	get(cid: string): OptimizeImage {
+		return new OptimizeImage(this.config, cid);
 	}
 
 	convert(url: string, gatewayPrefix?: string): Promise<string> {
@@ -463,6 +464,26 @@ class Gateways {
 
 	deleteSwap(cid: string): Promise<string> {
 		return deleteSwap(this.config, cid);
+	}
+}
+
+class OptimizeImage {
+	private config: PinataConfig | undefined;
+	private cid: string;
+	private options: OptimizeImageOptions = {};
+
+	constructor(config: PinataConfig | undefined, cid: string) {
+		this.config = config;
+		this.cid = cid;
+	}
+
+	optimizeImage(options: OptimizeImageOptions): OptimizeImage {
+		this.options = { ...this.options, ...options };
+		return this;
+	}
+
+	then(onfulfilled?: ((value: GetCIDResponse) => any) | null): Promise<any> {
+		return getCid(this.config, this.cid, this.options).then(onfulfilled);
 	}
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -182,6 +182,20 @@ export type GetCIDResponse = {
 	contentType: ContentType;
 };
 
+export type OptimizeImageOptions = {
+	width?: number;
+	height?: number;
+	dpr?: number;
+	fit?: "scaleDown" | "contain" | "cover" | "crop" | "pad";
+	gravity?: "auto" | "side" | string;
+	quality?: number;
+	format?: "auto" | "webp";
+	animation?: boolean;
+	sharpen?: number;
+	onError?: boolean;
+	metadata?: "keep" | "copyright" | "none";
+};
+
 export type GatewayAnalyticsQuery = {
 	gateway_domain: string;
 	start_date: string;

--- a/tests/gateway/getCid.test.ts
+++ b/tests/gateway/getCid.test.ts
@@ -1,5 +1,9 @@
 import { getCid } from "../../src/core/gateway/getCid";
-import type { PinataConfig, GetCIDResponse } from "../../src";
+import type {
+	PinataConfig,
+	GetCIDResponse,
+	OptimizeImageOptions,
+} from "../../src";
 import {
 	PinataError,
 	NetworkError,
@@ -81,6 +85,76 @@ describe("getCid function", () => {
 			data: mockBlob,
 			contentType: "application/octet-stream",
 		});
+	});
+
+	it("should include image optimization options in the URL", async () => {
+		const mockResponse = "optimized image data";
+		global.fetch = jest.fn().mockResolvedValueOnce({
+			ok: true,
+			headers: new Headers({ "content-type": "image/jpeg" }),
+			blob: jest.fn().mockResolvedValueOnce(new Blob([mockResponse])),
+		});
+
+		const options: OptimizeImageOptions = {
+			width: 100,
+			height: 100,
+			dpr: 2,
+			fit: "cover",
+			gravity: "center",
+			quality: 80,
+			format: "webp",
+			animation: true,
+			sharpen: 3,
+			onError: true,
+			metadata: "none",
+		};
+
+		await getCid(mockConfig, "QmTest...", options);
+
+		const expectedUrl =
+			"https://test.mypinata.cloud/ipfs/QmTest...?pinataGatewayToken=test_gateway_key&img-width=100&img-height=100&img-dpr=2&img-fit=cover&img-gravity=center&img-quality=80&img-format=webp&img-anim=true&img-sharpen=3&img-onerror=redirect&img-metadata=none";
+		expect(global.fetch).toHaveBeenCalledWith(expectedUrl);
+	});
+
+	it("should not include undefined image optimization options", async () => {
+		const mockResponse = "optimized image data";
+		global.fetch = jest.fn().mockResolvedValueOnce({
+			ok: true,
+			headers: new Headers({ "content-type": "image/jpeg" }),
+			blob: jest.fn().mockResolvedValueOnce(new Blob([mockResponse])),
+		});
+
+		const options: OptimizeImageOptions = {
+			width: 100,
+			height: undefined,
+			quality: 80,
+		};
+
+		await getCid(mockConfig, "QmTest...", options);
+
+		const expectedUrl =
+			"https://test.mypinata.cloud/ipfs/QmTest...?pinataGatewayToken=test_gateway_key&img-width=100&img-quality=80";
+		expect(global.fetch).toHaveBeenCalledWith(expectedUrl);
+	});
+
+	it("should handle boolean values in image optimization options", async () => {
+		const mockResponse = "optimized image data";
+		global.fetch = jest.fn().mockResolvedValueOnce({
+			ok: true,
+			headers: new Headers({ "content-type": "image/jpeg" }),
+			blob: jest.fn().mockResolvedValueOnce(new Blob([mockResponse])),
+		});
+
+		const options: OptimizeImageOptions = {
+			width: 100,
+			animation: false,
+		};
+
+		await getCid(mockConfig, "QmTest...", options);
+
+		const expectedUrl =
+			"https://test.mypinata.cloud/ipfs/QmTest...?pinataGatewayToken=test_gateway_key&img-width=100&img-anim=false";
+		expect(global.fetch).toHaveBeenCalledWith(expectedUrl);
 	});
 
 	it("should throw ValidationError if config is missing", async () => {


### PR DESCRIPTION
Adds a new optional `optimizeImage()` method to the `gateways.get` allowing you to use the existing [Image Optimizations API](https://docs.pinata.cloud/gateways/image-optimizations). Satisfies issue #13 