### PR TITLE
fix: Updated the response of `groups.list`

### DIFF
--- a/src/core/pinataSDK.ts
+++ b/src/core/pinataSDK.ts
@@ -788,7 +788,7 @@ class FilterGroups {
 
 	then(
 		onfulfilled?: ((value: GroupResponseItem[]) => any) | null,
-	): Promise<any> {
+	): Promise<GroupResponseItem[]> {
 		return listGroups(this.config, this.query).then(onfulfilled);
 	}
 


### PR DESCRIPTION
Previously `groups.list` was returning `any`, fixed to be `GroupResponseItem[]`