### PR TITLE
feat: Add name query to list groups

### DIFF
--- a/src/core/groups/listGroups.ts
+++ b/src/core/groups/listGroups.ts
@@ -67,12 +67,11 @@ export const listGroups = async (
 	const params = new URLSearchParams();
 
 	if (options) {
-		const { pageToken, nameContains, limit, isPublic } = options;
+		const { pageToken, name, limit, isPublic } = options;
 
 		if (pageToken) params.append("pageToken", pageToken.toString());
 		if (isPublic) params.append("isPublic", isPublic.toString());
-		if (nameContains !== undefined)
-			params.append("nameContains", nameContains.toString());
+		if (name) params.append("name", name);
 		if (limit !== undefined) params.append("limit", limit.toString());
 	}
 

--- a/src/core/pinataSDK.ts
+++ b/src/core/pinataSDK.ts
@@ -673,10 +673,10 @@ class FilterGroups {
 		this.config = config;
 	}
 
-	// name(nameContains: string): FilterGroups {
-	// 	this.query.nameContains = nameContains;
-	// 	return this;
-	// }
+	name(name: string): FilterGroups {
+		this.query.name = name;
+		return this;
+	}
 
 	limit(limit: number): FilterGroups {
 		this.query.limit = limit;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -326,7 +326,7 @@ export type GroupResponseItem = {
 };
 
 export type GroupQueryOptions = {
-	nameContains?: string;
+	name?: string;
 	limit?: number;
 	pageToken?: string;
 	isPublic?: boolean;


### PR DESCRIPTION
Adds a new filter method when using `pinata.groups.list()`
- `name`