### PR TITLE
feat: Added optional param of gateway to createSignedURL

### DIFF
--- a/src/core/gateway/createSignedURL.ts
+++ b/src/core/gateway/createSignedURL.ts
@@ -19,7 +19,17 @@ export const createSignedURL = async (
 		throw new ValidationError("Pinata configuration is missing");
 	}
 
-	let newUrl: string = `${config?.pinataGateway}/files/${options.cid}`;
+	let baseUrl: string | undefined;
+
+	if (options?.gateway) {
+		baseUrl = options.gateway.startsWith("https://")
+			? options.gateway
+			: `https://${options.gateway}`;
+	} else {
+		baseUrl = config.pinataGateway;
+	}
+
+	let newUrl: string = `${baseUrl}/files/${options.cid}`;
 
 	const params = new URLSearchParams();
 
@@ -41,6 +51,7 @@ export const createSignedURL = async (
 	}
 
 	const queryString = params.toString();
+
 	if (queryString) {
 		newUrl += `?${queryString}`;
 	}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -162,6 +162,7 @@ export type SignedUrlOptions = {
 	cid: string;
 	date?: number;
 	expires: number;
+	gateway?: string;
 };
 
 export type GatewayAnalyticsQuery = {

--- a/tests/gateway/createSignedURL.test.ts
+++ b/tests/gateway/createSignedURL.test.ts
@@ -169,4 +169,26 @@ describe("createSignedURL function", () => {
 			}),
 		);
 	});
+
+	it("should use custom gateway if provided in options", async () => {
+		const customGatewayOptions = {
+			...mockOptions,
+			gateway: "https://custom.gateway.com",
+		};
+		global.fetch = jest.fn().mockResolvedValueOnce({
+			ok: true,
+			json: () => Promise.resolve({ data: "signed_url" }),
+		});
+
+		await createSignedURL(mockConfig, customGatewayOptions, mockImageOpts);
+
+		expect(global.fetch).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({
+				body: expect.stringContaining(
+					'"url":"https://custom.gateway.com/files/QmTest...?img-width=100&img-height=100&img-dpr=2&img-fit=contain&img-gravity=auto&img-quality=80&img-format=webp&img-anim=true&img-sharpen=3&img-onerror=redirect&img-metadata=keep"',
+				),
+			}),
+		);
+	});
 });


### PR DESCRIPTION
This PR makes one small change to the `gateways.createSignURL` method. Before the method would use the gateway URL that was part of the config. Now you can pass in an optional gateway domain when calling the method. 

```typescript
const url = await pinata.gateways.createSignedURL({
	cid: "bafkreih5aznjvttude6c3wbvqeebb6rlx5wkbzyppv7garjiubll2ceym4",
	expires: 30,
        gateway: "discordpinnie.mypinata.cloud"
 });
```