### PR TITLE
chore: Added option for no group in listing files

### DIFF
--- a/src/core/files/list.ts
+++ b/src/core/files/list.ts
@@ -92,6 +92,7 @@ export const listFiles = async (
 			pageToken,
 			cidPending,
 			metadata,
+			noGroup,
 		} = options;
 
 		if (limit) params.append("limit", limit.toString());
@@ -102,6 +103,7 @@ export const listFiles = async (
 		if (order) params.append("order", order);
 		if (pageToken) params.append("pageToken", pageToken);
 		if (cidPending) params.append("cidPending", "true");
+		if (noGroup) params.append("group", "null");
 		if (metadata && typeof metadata === "object") {
 			Object.entries(metadata).forEach(([key, value]) => {
 				params.append(`metadata[${key}]`, value.toString());

--- a/src/core/pinataSDK.ts
+++ b/src/core/pinataSDK.ts
@@ -343,6 +343,11 @@ class FilterFiles {
 		return this;
 	}
 
+	noGroup(noGroup: boolean): FilterFiles {
+		this.query.noGroup = noGroup;
+		return this;
+	}
+
 	pageToken(pageToken: string): FilterFiles {
 		this.query.pageToken = pageToken;
 		return this;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -77,6 +77,7 @@ export type FileListResponse = {
 export type FileListQuery = {
 	name?: string;
 	group?: string;
+	noGroup?: boolean;
 	mimeType?: string;
 	cid?: string;
 	cidPending?: boolean;


### PR DESCRIPTION
Adds the ability to list files that are not part of a group

```
pinata.files.list().noGroup(true)
```