### PR TITLE
fix: Sliced charset from content type header

### DIFF
--- a/src/core/gateway/getCid.ts
+++ b/src/core/gateway/getCid.ts
@@ -137,7 +137,8 @@ export const getCid = async (
 			);
 		}
 
-		const contentType: string | null = request.headers.get("content-type");
+		const contentType: string | null =
+			request.headers.get("content-type")?.split(";")[0] || null;
 
 		if (contentType?.includes("application/json")) {
 			data = await request.json();


### PR DESCRIPTION
This PR fixes issue #48 where the content type was not being reflected corrected in `gateways.get` due to a new charset value. 