### PR TITLE
chore: Refactored vectors to use uploadUrl and include returnFile for queries

### DIFF
--- a/src/core/files/deleteFileVectors.ts
+++ b/src/core/files/deleteFileVectors.ts
@@ -30,8 +30,8 @@ export const deleteFileVectors = async (
 
 	let endpoint: string = "https://uploads.pinata.cloud/v3";
 
-	if (config.endpointUrl) {
-		endpoint = config.endpointUrl;
+	if (config.uploadUrl) {
+		endpoint = config.uploadUrl;
 	}
 
 	try {

--- a/src/core/files/vectorizeFile.ts
+++ b/src/core/files/vectorizeFile.ts
@@ -30,8 +30,8 @@ export const vectorizeFile = async (
 
 	let endpoint: string = "https://uploads.pinata.cloud/v3";
 
-	if (config.endpointUrl) {
-		endpoint = config.endpointUrl;
+	if (config.uploadUrl) {
+		endpoint = config.uploadUrl;
 	}
 
 	try {

--- a/src/core/pinataSDK.ts
+++ b/src/core/pinataSDK.ts
@@ -191,7 +191,9 @@ class Files {
 		return vectorizeFile(this.config, fileId);
 	}
 
-	queryVectors(options: VectorizeQuery): Promise<VectorizeQueryResponse> {
+	queryVectors(
+		options: VectorizeQuery,
+	): Promise<VectorizeQueryResponse | GetCIDResponse> {
 		return vectorizeQuery(this.config, options);
 	}
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -390,6 +390,7 @@ export type VectorizeFileResponse = {
 export type VectorizeQuery = {
 	groupId: string;
 	query: string;
+	returnFile?: boolean;
 };
 
 export type VectorQueryMatch = {


### PR DESCRIPTION
This updates the files.vectors methods to use the uploadUrl for the config instead of the endpointUrl. It also adds a new returnFile parameter for vector queries.