### PR TITLE
feat: Added presigned upload urls

### DIFF
--- a/src/core/pinataSDK.ts
+++ b/src/core/pinataSDK.ts
@@ -41,6 +41,7 @@ import type {
 	VectorizeFileResponse,
 	VectorizeQuery,
 	VectorizeQueryResponse,
+	SignedUploadUrlOptions,
 } from "./types";
 import { testAuthentication } from "./authentication/testAuthentication";
 import { uploadFile } from "./uploads/file";
@@ -78,6 +79,7 @@ import { createSignedURL } from "./gateway/createSignedURL";
 import { vectorizeFile } from "./files/vectorizeFile";
 import { vectorizeQuery } from "./files/vectorizeQuery";
 import { deleteFileVectors } from "./files/deleteFileVectors";
+import { createSignedUploadURL } from "./uploads/createSignedUploadURL";
 
 const formatConfig = (config: PinataConfig | undefined) => {
 	let gateway = config?.pinataGateway;
@@ -213,6 +215,7 @@ class UploadBuilder<T> {
 	private keys: string | undefined;
 	private groupId: string | undefined;
 	private vector: boolean | undefined;
+	private uploadUrl: string | undefined;
 
 	constructor(
 		config: PinataConfig | undefined,
@@ -239,6 +242,11 @@ class UploadBuilder<T> {
 
 	vectorize(): UploadBuilder<T> {
 		this.vector = true;
+		return this;
+	}
+
+	url(url: string): UploadBuilder<T> {
+		this.uploadUrl = url;
 		return this;
 	}
 
@@ -274,6 +282,9 @@ class UploadBuilder<T> {
 		}
 		if (this.vector) {
 			options.vectorize = this.vector;
+		}
+		if (this.uploadUrl) {
+			options.url = this.uploadUrl;
 		}
 		this.args[this.args.length - 1] = options;
 		return this.uploadFunction(this.config, ...this.args).then(
@@ -321,6 +332,10 @@ class Upload {
 
 	json(data: object, options?: UploadOptions): UploadBuilder<UploadResponse> {
 		return new UploadBuilder(this.config, uploadJson, data, options);
+	}
+
+	createSignedURL(options: SignedUploadUrlOptions): Promise<string> {
+		return createSignedUploadURL(this.config, options);
 	}
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -52,6 +52,7 @@ export type UploadOptions = {
 	keys?: string;
 	groupId?: string;
 	vectorize?: boolean;
+	url?: string;
 };
 
 export type DeleteResponse = {
@@ -402,4 +403,13 @@ export type VectorQueryMatch = {
 export type VectorizeQueryResponse = {
 	count: number;
 	matches: VectorQueryMatch[];
+};
+
+export type SignedUploadUrlOptions = {
+	date?: number;
+	expires: number;
+	groupId?: string;
+	name?: string;
+	keyvalues?: Record<string, string>;
+	vectorize?: boolean;
 };

--- a/src/core/uploads/base64.ts
+++ b/src/core/uploads/base64.ts
@@ -91,6 +91,45 @@ export const uploadBase64 = async (
 		endpoint = config.uploadUrl;
 	}
 
+	if (options?.url) {
+		try {
+			const request = await fetch(options.url, {
+				method: "POST",
+				body: data,
+			});
+
+			if (!request.ok) {
+				const errorData = await request.text();
+				if (request.status === 401 || request.status === 403) {
+					throw new AuthenticationError(
+						`Authentication failed: ${errorData}`,
+						request.status,
+						errorData,
+					);
+				}
+				throw new NetworkError(
+					`HTTP error: ${errorData}`,
+					request.status,
+					errorData,
+				);
+			}
+
+			const res = await request.json();
+			const resData: UploadResponse = res.data;
+			return resData;
+		} catch (error) {
+			if (error instanceof PinataError) {
+				throw error;
+			}
+			if (error instanceof Error) {
+				throw new PinataError(`Error processing base64: ${error.message}`);
+			}
+			throw new PinataError(
+				"An unknown error occurred while trying to upload base64",
+			);
+		}
+	}
+
 	try {
 		const request = await fetch(`${endpoint}/files`, {
 			method: "POST",

--- a/src/core/uploads/createSignedUploadURL.ts
+++ b/src/core/uploads/createSignedUploadURL.ts
@@ -1,0 +1,102 @@
+import type { PinataConfig, SignedUploadUrlOptions } from "../types";
+import {
+	PinataError,
+	NetworkError,
+	AuthenticationError,
+	ValidationError,
+} from "../../utils/custom-errors";
+
+export const createSignedUploadURL = async (
+	config: PinataConfig | undefined,
+	options: SignedUploadUrlOptions,
+): Promise<string> => {
+	if (!config) {
+		throw new ValidationError("Pinata configuration is missing");
+	}
+
+	type PayloadData = {
+		date: number;
+		expires: number;
+		group_id?: string;
+		name?: string;
+		keyvalues?: Record<string, string>;
+	};
+
+	const date = options?.date || Math.floor(new Date().getTime() / 1000);
+
+	const payload: PayloadData = {
+		date: date,
+		expires: options.expires,
+	};
+
+	if (options.groupId) {
+		payload.group_id = options.groupId;
+	}
+
+	if (options.name) {
+		payload.name = options.name;
+	}
+
+	if (options.keyvalues) {
+		payload.keyvalues = options.keyvalues;
+	}
+
+	let endpoint: string = "https://uploads.pinata.cloud/v3";
+
+	if (config.uploadUrl) {
+		endpoint = config.uploadUrl;
+	}
+
+	let headers: Record<string, string>;
+
+	if (config.customHeaders && Object.keys(config.customHeaders).length > 0) {
+		headers = {
+			Authorization: `Bearer ${config.pinataJwt}`,
+			"Content-Type": "application/json",
+			...config.customHeaders,
+		};
+	} else {
+		headers = {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${config.pinataJwt}`,
+			Source: "sdk/createSignURL",
+		};
+	}
+
+	try {
+		const request = await fetch(`${endpoint}/files/sign`, {
+			method: "POST",
+			headers: headers,
+			body: JSON.stringify(payload),
+		});
+
+		if (!request.ok) {
+			const errorData = await request.text();
+			if (request.status === 401 || request.status === 403) {
+				throw new AuthenticationError(
+					`Authentication Failed: ${errorData}`,
+					request.status,
+					errorData,
+				);
+			}
+			throw new NetworkError(
+				`HTTP error: ${errorData}`,
+				request.status,
+				errorData,
+			);
+		}
+
+		const res = await request.json();
+		return res.data;
+	} catch (error) {
+		if (error instanceof PinataError) {
+			throw error;
+		}
+		if (error instanceof Error) {
+			throw new PinataError(
+				`Error processing createSignedURL: ${error.message}`,
+			);
+		}
+		throw new PinataError("An unknown error occurred while getting signed url");
+	}
+};

--- a/src/core/uploads/file.ts
+++ b/src/core/uploads/file.ts
@@ -183,6 +183,47 @@ export const uploadFile = async (
 
 	const data = new FormData();
 	data.append("file", file, file.name);
+
+	if (options?.url) {
+		try {
+			const request = await fetch(options.url, {
+				method: "POST",
+				headers: headers,
+				body: data,
+			});
+
+			if (!request.ok) {
+				const errorData = await request.text();
+				if (request.status === 401 || request.status === 403) {
+					throw new AuthenticationError(
+						`Authentication failed: ${errorData}`,
+						request.status,
+						errorData,
+					);
+				}
+				throw new NetworkError(
+					`HTTP error: ${errorData}`,
+					request.status,
+					errorData,
+				);
+			}
+
+			const res = await request.json();
+			const resData: UploadResponse = res.data;
+			return resData;
+		} catch (error) {
+			if (error instanceof PinataError) {
+				throw error;
+			}
+			if (error instanceof Error) {
+				throw new PinataError(`Error processing base64: ${error.message}`);
+			}
+			throw new PinataError(
+				"An unknown error occurred while trying to upload base64",
+			);
+		}
+	}
+
 	data.append("name", options?.metadata?.name || file.name || "File from SDK");
 	if (options?.groupId) {
 		data.append("group_id", options.groupId);

--- a/src/core/uploads/file.ts
+++ b/src/core/uploads/file.ts
@@ -75,15 +75,25 @@ export const uploadFile = async (
 		}
 
 		const name = options?.metadata?.name || file.name || "File from SDK";
+
 		let metadata: string = `filename ${btoa(name)},filetype ${btoa(file.type)}`;
+
 		if (options?.groupId) {
 			metadata + `,group_id ${btoa(options.groupId)}`;
 		}
+
 		if (options?.metadata?.keyvalues) {
 			metadata +
 				`,keyvalues ${btoa(JSON.stringify(options.metadata.keyvalues))}`;
 		}
-		const urlReq = await fetch(`${endpoint}/files`, {
+
+		let updatedEndpoint: string = `${endpoint}/files`;
+
+		if (options?.url) {
+			updatedEndpoint = options.url;
+		}
+
+		const urlReq = await fetch(updatedEndpoint, {
 			method: "POST",
 			headers: {
 				"Upload-Length": `${file.size}`,

--- a/src/core/uploads/json.ts
+++ b/src/core/uploads/json.ts
@@ -97,6 +97,45 @@ export const uploadJson = async <T extends JsonBody>(
 		endpoint = config.uploadUrl;
 	}
 
+	if (options?.url) {
+		try {
+			const request = await fetch(options.url, {
+				method: "POST",
+				body: data,
+			});
+
+			if (!request.ok) {
+				const errorData = await request.text();
+				if (request.status === 401 || request.status === 403) {
+					throw new AuthenticationError(
+						`Authentication failed: ${errorData}`,
+						request.status,
+						errorData,
+					);
+				}
+				throw new NetworkError(
+					`HTTP error: ${errorData}`,
+					request.status,
+					errorData,
+				);
+			}
+
+			const res = await request.json();
+			const resData: UploadResponse = res.data;
+			return resData;
+		} catch (error) {
+			if (error instanceof PinataError) {
+				throw error;
+			}
+			if (error instanceof Error) {
+				throw new PinataError(`Error processing base64: ${error.message}`);
+			}
+			throw new PinataError(
+				"An unknown error occurred while trying to upload base64",
+			);
+		}
+	}
+
 	try {
 		const request = await fetch(`${endpoint}/files`, {
 			method: "POST",

--- a/src/core/uploads/url.ts
+++ b/src/core/uploads/url.ts
@@ -103,6 +103,45 @@ export const uploadUrl = async (
 		endpoint = config.uploadUrl;
 	}
 
+	if (options?.url) {
+		try {
+			const request = await fetch(options.url, {
+				method: "POST",
+				body: data,
+			});
+
+			if (!request.ok) {
+				const errorData = await request.text();
+				if (request.status === 401 || request.status === 403) {
+					throw new AuthenticationError(
+						`Authentication failed: ${errorData}`,
+						request.status,
+						errorData,
+					);
+				}
+				throw new NetworkError(
+					`HTTP error: ${errorData}`,
+					request.status,
+					errorData,
+				);
+			}
+
+			const res = await request.json();
+			const resData: UploadResponse = res.data;
+			return resData;
+		} catch (error) {
+			if (error instanceof PinataError) {
+				throw error;
+			}
+			if (error instanceof Error) {
+				throw new PinataError(`Error processing base64: ${error.message}`);
+			}
+			throw new PinataError(
+				"An unknown error occurred while trying to upload base64",
+			);
+		}
+	}
+
 	try {
 		const request = await fetch(`${endpoint}/files`, {
 			method: "POST",


### PR DESCRIPTION
We are starting the initial work to enable pre-signed upload URLs to the SDK. The current usage will look something like this:

```typescript
const url = await pinata.upload.createSignedURL({
	expires: 300,
	name: file.name,
	groupId: group.id,
	keyvalues: {
		awesome: "true",
	},
});
const upload = await pinata.upload.file(file).url(url);
```

All of the data that would normally be sent with the upload request will be part of the signed URL creation instead. With this a simple upload can be made with all the upload options included. 