### PR TITLE
feat: Add new key resources

### DIFF
--- a/src/core/types/keys.ts
+++ b/src/core/types/keys.ts
@@ -1,7 +1,20 @@
 export type KeyPermissions = {
 	admin?: boolean;
 	endpoints?: Endpoints;
+	resources?: ResourcePermission[];
 };
+
+export type ResourcePermission =
+	| "org:read"
+	| "org:write"
+	| "org:files:read"
+	| "org:files:write"
+	| "org:groups:read"
+	| "org:groups:write"
+	| "org:gateways:read"
+	| "org:gateways:write"
+	| "org:analytics:read"
+	| "org:analytics:write";
 
 export type Endpoints = {
 	data?: DataEndponts;


### PR DESCRIPTION
This updates the createKey options to include a new set of resource
permissions, allowing users to scope keys to specific resources like
files, groups, gateways, or analytics. More info can be found in the
[docs](https://docs.pinata.cloud/api-reference/endpoint/v3-create-api-key)
