### PR TITLE
chore: Removed dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,6 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.2.2"
   },
-  "dependencies": {
-    "node-fetch": "^3.3.1"
-  },
   "engines": {
     "node": ">=20"
   }


### PR DESCRIPTION
Removed old use of node-fetch now that SDK requires Node v.20.* per #72
